### PR TITLE
feat(api): Add authentication to create, delete, and upload routes

### DIFF
--- a/src/pages/api/create.js
+++ b/src/pages/api/create.js
@@ -7,14 +7,11 @@ const cosmic = createBucketClient({
   writeKey: process.env.COSMIC_WRITE_KEY,
 });
 
-const createHandler = async (
-  {
-    body: {
-      title, description, price, count, image, categories, email,
-    },
-  },
-  res,
-) => {
+const createHandler = async (req, res) => {
+  const {
+    title, description, price, count, image, categories, email,
+  } = req.body;
+
   const metadata = {
     description,
     price: Number(price),
@@ -33,13 +30,9 @@ const createHandler = async (
     });
     res.status(200).json(data);
   } catch (error) {
-    res.status(error.status).json(error.message);
+    res.status(error.status || 500).json({ error: error.message });
   }
 };
 
-const handler = async (req, res) => {
-  await haveSecret(req, res, async () => {
-    await createHandler(req, res);
-  });
-};
-export default handler;
+// Wrap createHandler with haveSecret
+export default haveSecret(createHandler);

--- a/src/pages/api/delete.js
+++ b/src/pages/api/delete.js
@@ -17,9 +17,5 @@ const deleteHandler = async (req, res) => {
   }
 };
 
-const handler = async (req, res) => {
-  await haveSecret(req, res, async () => {
-    await deleteHandler(req, res);
-  });
-};
-export default handler;
+// Wrap deleteHandler with haveSecret
+export default haveSecret(deleteHandler);

--- a/src/pages/api/secret.js
+++ b/src/pages/api/secret.js
@@ -1,26 +1,26 @@
+// Import necessary modules
 import { withIronSessionApiRoute } from 'iron-session/next';
 import { APP_KEY } from '../../utils/constants/appConstants';
 
 require('dotenv').config();
 
-const haveSecret = withIronSessionApiRoute(
-  // eslint-disable-next-line consistent-return
-  async (req, res, next) => {
-    try {
-      const { user } = req.session;
-      if (!user) {
-        return res.status(401).json('Accès refusé');
-      }
-      req.userId = user.id;
-      next();
-    } catch (error) {
-      res.status(500).json(error.message);
+// The haveSecret higher-order function
+const haveSecret = (handler) => withIronSessionApiRoute(async (req, res) => {
+  try {
+    const { user } = req.session;
+    if (!user) {
+      return res.status(401).json({ error: 'Accès refusé' });
     }
-  },
-  {
-    cookieName: APP_KEY,
-    password: process.env.SECRET_KEY,
-  },
-);
+    req.userId = user.id;
+
+    // Call the original handler now that we've handled the session check
+    await handler(req, res);
+  } catch (error) {
+    res.status(error.status || 500).json({ error: error.message });
+  }
+}, {
+  cookieName: APP_KEY,
+  password: process.env.SECRET_KEY,
+});
 
 export default haveSecret;

--- a/src/pages/api/upload.js
+++ b/src/pages/api/upload.js
@@ -1,20 +1,25 @@
+// Import necessary modules and your haveSecret function
 import { createBucketClient } from '@cosmicjs/sdk';
-import formidable from 'formidable';
 import fs from 'fs';
 import haveSecret from './secret';
 
+const formidable = require('formidable');
+
+// Set up your Cosmic client
 const cosmic = createBucketClient({
   bucketSlug: process.env.NEXT_PUBLIC_COSMIC_BUCKET_SLUG,
   readKey: process.env.NEXT_PUBLIC_COSMIC_READ_KEY,
   writeKey: process.env.COSMIC_WRITE_KEY,
 });
 
+// Disable the default body parser for this route
 export const config = {
   api: {
     bodyParser: false,
   },
 };
 
+// Function to save the file
 const saveFile = async (file) => {
   const filedata = fs.readFileSync(file?.filepath);
   const media = {
@@ -22,9 +27,7 @@ const saveFile = async (file) => {
     buffer: filedata,
   };
   try {
-    await cosmic.media.insertOne({
-      media,
-    });
+    await cosmic.media.insertOne({ media });
     await fs.unlinkSync(file?.filepath);
     return await cosmic.media.insertOne({ media });
   } catch (error) {
@@ -33,25 +36,33 @@ const saveFile = async (file) => {
 };
 
 async function uploadHandler(req, res) {
-  const form = formidable({});
-
-  try {
-    await form.parse(req, async (err, fields, files) => {
-      if (err) {
-        res.status(err.status).json({ error: 'Erreur lors du traitement du fichier' });
-        return;
-      }
-      const cosmicRes = await saveFile(files.file[0]);
-      res.status(200).json(cosmicRes);
-    });
-  } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return undefined; // Explicitly return undefined
   }
+
+  const form = new formidable.IncomingForm();
+
+  // Wrap the form.parse in a new Promise
+  return new Promise((resolve, reject) => {
+    form.parse(req, async (err, fields, files) => {
+      if (err) {
+        res.status(err.status || 500).json({ error: 'Erreur lors du traitement du fichier' });
+        reject(err); // Reject the promise
+        return undefined; // Explicitly return undefined
+      }
+      try {
+        const cosmicRes = await saveFile(files.file[0]);
+        res.status(200).json(cosmicRes);
+        resolve(); // Resolve the promise
+      } catch (error) {
+        res.status(error.status || 500).json({ error: error.message });
+        reject(error); // Reject the promise
+      }
+      return undefined; // Explicitly return undefined
+    });
+  });
 }
 
-const handler = async (req, res) => {
-  await haveSecret(req, res, async () => {
-    await uploadHandler(req, res);
-  });
-};
-export default handler;
+// Export your uploadHandler wrapped with haveSecret
+export default haveSecret(uploadHandler);


### PR DESCRIPTION
This commit adds authentication to the `create`, `delete`, and `upload` routes in the API. The `create` and `delete` routes are now wrapped with the `haveSecret` higher-order function, which checks for a user session and returns an appropriate response if the user is not authenticated. The `upload` route also utilizes the `haveSecret` function and additionally disables the default body parser for the route. The `saveFile` function is now wrapped in a Promise to handle errors properly and resolves with the successful response.