### PR TITLE
Add "@vercel/speed-insights" package to package.json and pnpm-lock.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@cosmicjs/sdk": "^1.0.9",
     "@microsoft/eslint-formatter-sarif": "2.1.7",
     "@vercel/analytics": "^1.1.1",
+    "@vercel/speed-insights": "^1.0.1",
     "classnames": "^2.3.2",
     "dotenv": "^16.3.1",
     "formidable": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@vercel/analytics':
     specifier: ^1.1.1
     version: 1.1.1
+  '@vercel/speed-insights':
+    specifier: ^1.0.1
+    version: 1.0.1
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
@@ -484,6 +487,11 @@ packages:
     resolution: {integrity: sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==}
     dependencies:
       server-only: 0.0.1
+    dev: false
+
+  /@vercel/speed-insights@1.0.1:
+    resolution: {integrity: sha512-cm8KTTsDgS1AbWsgIEZuMoyPUjclzeqJihyLp0tnA21B/x9iTE8hu2S5zM+/DBzihuHxWL1dx9pCWk22ctMFWQ==}
+    requiresBuild: true
     dev: false
 
   /acorn-jsx@5.3.2(acorn@8.11.2):

--- a/src/utils/context/StateContext.js
+++ b/src/utils/context/StateContext.js
@@ -8,6 +8,7 @@ import {
 import { toast } from 'react-hot-toast';
 // eslint-disable-next-line import/no-unresolved
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const Context = createContext();
 
@@ -92,6 +93,7 @@ export function StateContext({ children }) {
     <Context.Provider value={contextValues}>
       {children}
       <Analytics />
+      <SpeedInsights />
     </Context.Provider>
   );
 }


### PR DESCRIPTION
This commit adds the "@vercel/speed-insights" package to both the package.json and pnpm-lock.yaml files.

[@vercel/speed-insights v1.0.1]

Context:
- "["@vercel/speed-insights": "^1.0.1"](https://www.npmjs.com/package/@vercel/speed-insights) is added as a dependency in package.json
- The package is also added to pnpm-lock.yaml with a version specifier of "^1.0.1"
- A resolution and requiresBuild field are included in the pnpm-lock.yaml entry for "@vercel/speed-insights"